### PR TITLE
Improve validation of entity numbers

### DIFF
--- a/R/brreg-utils.R
+++ b/R/brreg-utils.R
@@ -160,19 +160,24 @@ clean_entity_input <- function(x) {
 verify_entity_number <- function(x) {
   msg <- '{x} is not a valid organization number'
   if (grepl('\\d{9}', x)) {
-    if (!mod11(x)) return(cli::cli_abort(msg))
+    if (!is_valid_entity(x)) return(cli::cli_abort(msg))
   } else {
     return(cli::cli_abort(msg))
   }
   invisible(TRUE)
 }
 
-#' mod11
+#' is_valid_entity
 #' Check validity of Norwegian organization numbers
 #' @noRd
-mod11 <- function(x, n = 8, weights = c(3,2,7,6,5,4,3,2)) {
-  x <- as.character(x)
+is_valid_entity <- function(x) {
+  weights <- c(3,2,7,6,5,4,3,2)
+  # Early return if number doesn't have 9 digits
+  if (nchar(x) != 9) return(FALSE)
+  # Early return if number doesn't start with 8 or 9
+  if (!grepl('^[8-9]', x)) return(FALSE)
+  # Calculate mod11 check
   x <- as.integer(unlist(strsplit(x, '')))
-  k <- sum(weights * x[1:n]) %% 11
-  if (k == 0) k == x[n+1] else (11 - k) == x[n+1]
+  k <- sum(weights * x[1:8]) %% 11
+  if (k == 0) k == x[9] else (11 - k) == x[9]
 }

--- a/tests/testthat/test-brreg-utils.R
+++ b/tests/testthat/test-brreg-utils.R
@@ -23,12 +23,23 @@ test_that('verify_entity_number() works', {
   expect_error(verify_entity_number('972417806')) # not valid
 })
 
-test_that('mod11() works', {
-  expect_true(mod11(974760843))
-  expect_true(mod11(971524960))
-  expect_true(mod11(972417807))
-  expect_false(mod11(123456789))
-  expect_false(mod11(974760841))
-  expect_false(mod11(971524962))
-  expect_false(mod11(972417806))
+test_that('is_valid_entity() works', {
+
+  expect_true(is_valid_entity('801234569'))
+  expect_true(is_valid_entity('987654325'))
+  expect_true(is_valid_entity('974760843'))
+
+  expect_false(is_valid_entity('87654321'))    # Too short
+  expect_false(is_valid_entity('9876543210'))  # Too long
+  expect_false(is_valid_entity('723456789'))   # Bad first digit
+  expect_false(is_valid_entity('987654320'))   # Bad check control digit 1
+  expect_false(is_valid_entity('987654321'))   # Bad check control digit 2
+  expect_false(is_valid_entity('987654322'))   # Bad check control digit 3
+  expect_false(is_valid_entity('987654323'))   # Bad check control digit 4
+  expect_false(is_valid_entity('987654324'))   # Bad check control digit 5
+  expect_false(is_valid_entity('987654326'))   # Bad check control digit 6
+  expect_false(is_valid_entity('987654327'))   # Bad check control digit 7
+  expect_false(is_valid_entity('987654328'))   # Bad check control digit 8
+  expect_false(is_valid_entity('987654329'))   # Bad check control digit 9
+
 })


### PR DESCRIPTION
* Use {clever} inspired function
* Add handling of numbers that don't start with 8 or 9

Fixes #17. 